### PR TITLE
Allow sending arbitrary notifications to a Component.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,10 @@ When a component or its parent has joined it can send user events to the client.
 
 ### Subscriptions
 
-Every time a component joins or responds to an event the `Componet._subscriptions` set is reviewed to check if the component subscribes or not to some channel. In case a mutation in a model occurs `Component.mutation` will be called passing `mutation(channel: str, instance: Model, action: reactor.auto_broadcast.Action)`.
+Every time a component joins or responds to an event the `Componet._subscriptions` set is reviewed to check if the component subscribes or not to some channel.
+
+- In case a mutation in a model occurs `Component.mutation(channel: str, instance: Model, action: reactor.auto_broadcast.Action)` will be called.
+- In case you broadcast a message using `reactor.component.broadcast(channel, **kwargs)` this message will be sent to any component subscribed to `channel` using the method `Component.notification(channel, **kwargs)`.
 
 ### Disconnection
 
@@ -171,6 +174,8 @@ Instead use the class method `new` to create the instance.
 #### Subscriptions
 
 - `_subscriptions`: (default: `set()`) Defines which channels is this component subscribed to.
+- `mutation(channel, instance, action)` Called when autobroadcast is enabled and a model you are subscribed to changes.
+- `notification(channel, **kwargs)` Called when `reactor.component.broadcast(channel, **kwargs)` is used to send an arbitrary notification to components.
 
 #### Actions
 

--- a/reactor/auto_broadcast.py
+++ b/reactor/auto_broadcast.py
@@ -7,7 +7,7 @@ from django.dispatch import receiver
 
 from . import serializer
 from .settings import AUTO_BROADCAST
-from .utils import send_to_group
+from .utils import send_to
 
 __all__ = ("Action",)
 
@@ -39,10 +39,10 @@ if MODEL or MODEL_PK or RELATED:
         encoded_instance = serializer.encode(instance)
         action = Action.CREATED if created else Action.UPDATED
         if MODEL:
-            broadcast([name], encoded_instance, action)
+            notify_mutation([name], encoded_instance, action)
 
         if instance.pk is not None:
-            MODEL_PK and broadcast(
+            MODEL_PK and notify_mutation(
                 [f"{name}.{instance.pk}"],
                 encoded_instance,
                 action,
@@ -55,10 +55,10 @@ if MODEL or MODEL_PK or RELATED:
     def broadcast_pre_delete(sender, instance, **kwargs):
         name = sender._meta.model_name
         encoded_instance = serializer.encode(instance)
-        MODEL and broadcast([name], encoded_instance, Action.DELETED)
+        MODEL and notify_mutation([name], encoded_instance, Action.DELETED)
 
         if instance.pk is not None:
-            MODEL_PK and broadcast(
+            MODEL_PK and notify_mutation(
                 [f"{name}.{instance.pk}"],
                 encoded_instance,
                 Action.DELETED,
@@ -82,7 +82,7 @@ def broadcast_related(sender, instance, encoded_instance, action: Action):
                 f'{field["related_model_name"]}.{fk_id}.{field["related_name"]}'
                 for fk_id in fk_ids
             ]
-            broadcast(group_names, encoded_instance, action)
+            notify_mutation(group_names, encoded_instance, action)
 
 
 MODEL_RELATED_FIELDS = {}
@@ -103,7 +103,7 @@ def get_related_fields(model):
                                 "is_m2m": is_m2m,
                                 "name": field.attname,
                                 "related_name": related_name,
-                                "related_model_name": field.related_model._meta.model_name,
+                                "related_model_name": field.related_model._meta.model_name,  # noqa
                             }
                         )
         related_fields = MODEL_RELATED_FIELDS[model] = tuple(fields)
@@ -130,14 +130,14 @@ if M2M:
             model_name = model._meta.model_name
             attr_name = get_name_of(sender, model)
             updates = [f"{model_name}.{pk}.{attr_name}" for pk in pk_set or []]
-            broadcast([updates], encoded_instance, action)
+            notify_mutation([updates], encoded_instance, action)
 
             model = type(instance)
             model_name = model._meta.model_name
             attr_name = get_name_of(sender, model)
             update = f"{model_name}.{instance.pk}.{attr_name}"
-            broadcast(update)
-            broadcast(
+            notify_mutation(update)
+            notify_mutation(
                 *[f"{update}.{pk}" for pk in pk_set or []],
                 encoded_instance,
                 action,
@@ -153,7 +153,7 @@ def get_name_of(through, model):
             return model_field.name
 
 
-def broadcast(names, instance, action):
+def notify_mutation(names, instance, action):
     for name in [n.replace("_", "-") for n in names]:
         log.debug(f"<-> {action} {name}")
-        send_to_group(name, "model_mutation", instance=instance, action=action)
+        send_to(name, "model_mutation", instance=instance, action=action)

--- a/reactor/component.py
+++ b/reactor/component.py
@@ -14,7 +14,7 @@ from django.utils.safestring import mark_safe
 from pydantic import BaseModel, validate_arguments
 from pydantic.fields import Field
 
-from . import serializer, settings
+from . import serializer, settings, utils
 
 if settings.USE_HMIN:
     try:
@@ -27,6 +27,13 @@ else:
 
     def html_minify(html):
         return html
+
+
+__all__ = ("Component", "broadcast")
+
+
+def broadcast(channel, **kwargs):
+    utils.send_to(channel, type="notification", kwargs=kwargs)
 
 
 class ReactorMeta:
@@ -285,6 +292,9 @@ class Component(BaseModel):
         ...
 
     def mutation(self, channel, instance, action):
+        ...
+
+    def notification(self, channel, **kwargs):
         ...
 
     def destroy(self):

--- a/reactor/utils.py
+++ b/reactor/utils.py
@@ -1,4 +1,5 @@
 import inspect
+import typing as t
 from functools import wraps
 
 from asgiref.sync import async_to_sync
@@ -16,13 +17,14 @@ def on_commit(f):
     return wrapper
 
 
-def send_to_group(_whom, type, **kwargs):
-    if _whom:
+def send_to(channel: t.Optional[str], type: str, **kwargs):
+    """Sends a message of `type` to the"""
+    if channel:
 
         @on_commit
         def send_message():
             async_to_sync(get_channel_layer().group_send)(
-                _whom, dict(type=type, origin=_whom, **kwargs)
+                channel, dict(type=type, channel=channel, **kwargs)
             )
 
         send_message()

--- a/tests/fision/settings.py
+++ b/tests/fision/settings.py
@@ -20,6 +20,7 @@ BASE_DIR = up(up(os.path.abspath(__file__)))
 
 REACTOR = {
     "BOOST_PAGES": True,
+    "AUTO_BROADCAST": True,
 }
 
 


### PR DESCRIPTION
Adds the `reactor.component.broadcast(channel, **kwargs)` to send a notification to any `Component` subscribed to `channel`. he message is delivered in `Component.notification(channel, **kwargs)`.