### PR TITLE
remove recv_ prefixes in readme example, & typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Examples:
 Here any event inside that component will have the implicit argument `x` being send to the backend.
 
 ```html
-<div {% tag-header %}>
+<div {% tag_header %}>
   <input name="x"/>
   <button {% on "click" "submit" %}>Send</button>
 </div>
@@ -334,7 +334,7 @@ Here any event inside that component will have the implicit argument `x` being s
 Here any `submit_x` will send `x`, and `submit_y` will send just `y`.
 
 ```html
-<div {% tag-header %}>
+<div {% tag_header %}>
   <input name="x"/>
   <button {% on "click" "submit_x" %}>Send</button>
   <form>

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ The implicit arguments are taken from the `form` the element handling the event 
 
 Examples:
 
-Here any event inside that component will have the implicit argument `x` being send to the backend.
+Here any event inside that component will have the implicit argument `x` being sent to the backend.
 
 ```html
 <div {% tag_header %}>

--- a/README.md
+++ b/README.md
@@ -102,13 +102,13 @@ class XCounter(Component):
 
     amount: int = 0
 
-    async def recv_inc(self):
+    async def inc(self):
         self.amount += 1
 
-    async def recv_dec(self):
+    async def dec(self):
         self.amount -= 1
 
-    async def recv_set_to(self, amount: int):
+    async def set_to(self, amount: int):
         self.amount = amount
 ```
 


### PR DESCRIPTION
these are not needed any more in v5 and produce an error in Django.